### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,8 @@ build = "build.rs"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-serde_yaml = "0.7.5" # needs to be the same version as the one used by `yaml-merge-keys` -
-# emailed the maintainers if they could release the update of the dependencies
-yaml-merge-keys = {version= "0.2.1", features = ["serde_yaml"]}
+serde_yaml = "0.8"
+yaml-merge-keys = {version= "0.3", features = ["serde_yaml"]}
 heck = "0.3"
 regex = "1.0"
 


### PR DESCRIPTION
After my email to the maintainers a new version of yaml-merge-keys was released that catches up with new
serde_yaml. Updated both dependencies.